### PR TITLE
Harden run_linux.sh for broader distro compatibility

### DIFF
--- a/Tools/enc_test.py
+++ b/Tools/enc_test.py
@@ -1,4 +1,7 @@
-from Cryptodome.Cipher import AES
+try:
+    from Cryptodome.Cipher import AES
+except ImportError as exc:
+    raise ImportError("This test requires pycryptodome (Cryptodome.Cipher.AES).") from exc
 from struct import unpack, pack
 from binascii import hexlify
 

--- a/mtkclient/Library/Auth/sla.py
+++ b/mtkclient/Library/Auth/sla.py
@@ -2,10 +2,27 @@
 # -*- coding: utf-8 -*-
 # (c) B.Kerler 2018-2024 GPLv3 License
 
-from Cryptodome.Hash import SHA256
-from Cryptodome.Util.number import bytes_to_long, ceil_div, size, long_to_bytes
-from Cryptodome.Cipher import PKCS1_OAEP
-from Cryptodome.PublicKey import RSA
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Cryptodome.Hash import SHA256
+    from Cryptodome.Util.number import bytes_to_long, ceil_div, size, long_to_bytes
+    from Cryptodome.Cipher import PKCS1_OAEP
+    from Cryptodome.PublicKey import RSA
+except ImportError:
+    SHA256 = _MissingCryptoModule()
+    PKCS1_OAEP = _MissingCryptoModule()
+    RSA = _MissingCryptoModule()
+    bytes_to_long = _missing_crypto
+    ceil_div = _missing_crypto
+    size = _missing_crypto
+    long_to_bytes = _missing_crypto
 
 
 def customized_sign(n, e, msg):

--- a/mtkclient/Library/Auth/sla_keys.py
+++ b/mtkclient/Library/Auth/sla_keys.py
@@ -1,5 +1,17 @@
-from Cryptodome.PublicKey import RSA
-from Cryptodome.Util.number import bytes_to_long
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Cryptodome.PublicKey import RSA
+    from Cryptodome.Util.number import bytes_to_long
+except ImportError:
+    RSA = _MissingCryptoModule()
+    bytes_to_long = _missing_crypto
 
 
 class SlaKey:

--- a/mtkclient/Library/DA/xflash/xflash_lib.py
+++ b/mtkclient/Library/DA/xflash/xflash_lib.py
@@ -8,7 +8,19 @@ import sys
 from binascii import hexlify
 from struct import pack, unpack
 
-from Cryptodome.Util.number import bytes_to_long, long_to_bytes
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Cryptodome.Util.number import bytes_to_long, long_to_bytes
+except ImportError:
+    bytes_to_long = _missing_crypto
+    long_to_bytes = _missing_crypto
 
 from mtkclient.Library.Auth.sla import generate_da_sla_signature
 from mtkclient.Library.DA.xflash.xflash_flash_param import NandExtension

--- a/mtkclient/Library/DA/xml/xml_lib.py
+++ b/mtkclient/Library/DA/xml/xml_lib.py
@@ -6,13 +6,28 @@ import os
 from struct import pack, unpack
 from queue import Queue
 from threading import Thread
-
-from Cryptodome.Util.number import long_to_bytes
-from Cryptodome.Cipher import PKCS1_OAEP
-from Cryptodome.Hash import SHA256
-from Cryptodome.PublicKey import RSA
-from Cryptodome.Util.number import size, bytes_to_long
 from mtkclient.Library.DA.xml.xml_param import DataType, FtSystemOSE, LogLevel
+
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Cryptodome.Util.number import long_to_bytes, size, bytes_to_long
+    from Cryptodome.Cipher import PKCS1_OAEP
+    from Cryptodome.Hash import SHA256
+    from Cryptodome.PublicKey import RSA
+except ImportError:
+    long_to_bytes = _missing_crypto
+    size = _missing_crypto
+    bytes_to_long = _missing_crypto
+    PKCS1_OAEP = _MissingCryptoModule()
+    SHA256 = _MissingCryptoModule()
+    RSA = _MissingCryptoModule()
 from mtkclient.Library.utils import logsetup, LogBase
 from mtkclient.Library.error import ErrorHandler
 from mtkclient.Library.DA.daconfig import EmmcPartitionType, UFSPartitionType, DaStorage

--- a/mtkclient/Library/Hardware/hwcrypto_dxcc.py
+++ b/mtkclient/Library/Hardware/hwcrypto_dxcc.py
@@ -7,10 +7,24 @@
 import logging
 import hashlib
 from struct import pack
-from Crypto.Util.number import bytes_to_long
-from Crypto.Cipher import AES
-from Crypto.Util import Counter
 from mtkclient.Library.utils import LogBase, logsetup
+
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Crypto.Util.number import bytes_to_long
+    from Crypto.Cipher import AES
+    from Crypto.Util import Counter
+except ImportError:
+    bytes_to_long = _missing_crypto
+    AES = _MissingCryptoModule()
+    Counter = _MissingCryptoModule()
 
 Lcs = 0xA
 KceSet = 0xB

--- a/mtkclient/Library/cryptutils.py
+++ b/mtkclient/Library/cryptutils.py
@@ -3,12 +3,28 @@
 # (c) B.Kerler 2018-2024 GPLv3 License
 
 import hashlib
-from Cryptodome.Cipher import AES
-from Cryptodome.Util import Counter
-from Cryptodome.Hash import CMAC
-from Cryptodome.Util.number import long_to_bytes, bytes_to_long
 from binascii import hexlify
 import hmac
+
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Cryptodome.Cipher import AES
+    from Cryptodome.Util import Counter
+    from Cryptodome.Hash import CMAC
+    from Cryptodome.Util.number import long_to_bytes, bytes_to_long
+except ImportError:
+    AES = _MissingCryptoModule()
+    Counter = _MissingCryptoModule()
+    CMAC = _MissingCryptoModule()
+    long_to_bytes = _missing_crypto
+    bytes_to_long = _missing_crypto
 
 
 class PKCS1BaseException(Exception):

--- a/mtkclient/Library/mtk_preloader.py
+++ b/mtkclient/Library/mtk_preloader.py
@@ -8,7 +8,19 @@ from enum import Enum
 from struct import unpack, pack
 from binascii import hexlify
 
-from Cryptodome.Util.number import size
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Cryptodome.Util.number import size
+except ImportError:
+    size = _missing_crypto
+
 from mtkclient.Library.Auth.sla import generate_brom_sla_challenge
 from mtkclient.Library.settings import HwParam
 from mtkclient.Library.utils import LogBase, logsetup

--- a/mtkclient/cryptutils.py
+++ b/mtkclient/cryptutils.py
@@ -3,12 +3,28 @@
 # (c) B.Kerler 2018-2024 GPLv3 License
 
 import hashlib
-from Crypto.Cipher import AES
-from Crypto.Util import Counter
-from Crypto.Hash import CMAC
-from Crypto.Util.number import long_to_bytes, bytes_to_long
 from binascii import hexlify
 import hmac
+
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Crypto.Cipher import AES
+    from Crypto.Util import Counter
+    from Crypto.Hash import CMAC
+    from Crypto.Util.number import long_to_bytes, bytes_to_long
+except ImportError:
+    AES = _MissingCryptoModule()
+    Counter = _MissingCryptoModule()
+    CMAC = _MissingCryptoModule()
+    long_to_bytes = _missing_crypto
+    bytes_to_long = _missing_crypto
 
 
 class PKCS1BaseException(Exception):

--- a/mtkclient/mtk_preloader.py
+++ b/mtkclient/mtk_preloader.py
@@ -8,7 +8,19 @@ from enum import Enum
 from struct import unpack, pack
 from binascii import hexlify
 
-from Crypto.Util.number import size
+class _MissingCryptoModule:
+    def __getattr__(self, _name):
+        raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+
+def _missing_crypto(*_args, **_kwargs):
+    raise ImportError("Crypto backend is required for this operation. Install pycryptodome.")
+
+try:
+    from Crypto.Util.number import size
+except ImportError:
+    size = _missing_crypto
+
 from mtkclient.Library.Auth.sla import generate_brom_sla_challenge
 from mtkclient.Library.settings import HwParam
 from mtkclient.Library.utils import LogBase, logsetup

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -348,7 +348,7 @@ setup_virtual_environment() {
     
     # Define Python packages for virtual environment
     # Use pycryptodomex instead of pycryptodome to support "Cryptodome" imports
-    PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone keystone-engine pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
+    PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone keystone-engine pycryptodome pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
     
     # Activate virtual environment and install packages
     log "Installing Python packages in virtual environment..."
@@ -416,13 +416,15 @@ verify_pycryptodome_installation() {
 import sys
 try:
     from Crypto.Cipher import AES
+    from Crypto.Util.number import bytes_to_long
+    _ = bytes_to_long(b"\x01")
     print('pycryptodome (Crypto) import successful')
     sys.exit(0)
 except ImportError:
     try:
         from Cryptodome.Cipher import AES
-        print('pycryptodomex (Cryptodome) import successful')
-        sys.exit(0)
+        print('pycryptodomex found, but Crypto namespace is required')
+        sys.exit(2)
     except ImportError:
         print('Neither pycryptodome nor pycryptodomex found')
         sys.exit(1)
@@ -436,13 +438,15 @@ except ImportError:
 import sys
 try:
     from Crypto.Cipher import AES
+    from Crypto.Util.number import bytes_to_long
+    _ = bytes_to_long(b"\x01")
     print('pycryptodome (Crypto) import successful')
     sys.exit(0)
 except ImportError:
     try:
         from Cryptodome.Cipher import AES
-        print('pycryptodomex (Cryptodome) import successful')
-        sys.exit(0)
+        print('pycryptodomex found, but Crypto namespace is required')
+        sys.exit(2)
     except ImportError:
         print('Neither pycryptodome nor pycryptodomex found')
         sys.exit(1)
@@ -469,7 +473,7 @@ check_pycryptodome_status() {
     fi
     
     # Check if it's installed but not working (version conflict, etc.)
-    local check_cmd="python -c \"import pkg_resources; print([d for d in pkg_resources.working_set if d.project_name.lower() in ['pycryptodome', 'pycrypto']])\" 2>/dev/null || true"
+    local check_cmd="python -c \"import pkg_resources; print([d for d in pkg_resources.working_set if d.project_name.lower() in ['pycryptodome', 'pycryptodomex', 'pycrypto']])\" 2>/dev/null || true"
     
     if [ -n "$venv_dir" ] && [ -d "$venv_dir" ]; then
         local installed_packages=$(source "$venv_dir/bin/activate" && eval $check_cmd)
@@ -514,12 +518,12 @@ install_pycryptodome_fallback() {
             ;;
     esac
     
-    # Try different installation methods - prioritize pycryptodomex for Cryptodome imports
+    # Try different installation methods - prioritize pycryptodome for Crypto imports
     local install_methods=(
-        "pip install pycryptodomex --upgrade $extra_flags"
-        "pip install pycryptodomex --no-cache-dir $extra_flags"
-        "pip install pycryptodomex --force-reinstall $extra_flags"
         "pip install pycryptodome --upgrade $extra_flags"
+        "pip install pycryptodome --no-cache-dir $extra_flags"
+        "pip install pycryptodome --force-reinstall $extra_flags"
+        "pip install pycryptodomex --upgrade $extra_flags"
         "pip install pycryptodome --no-cache-dir $extra_flags"
         "pip install pycryptodome --force-reinstall $extra_flags"
         "pip install pycryptodomex --no-deps --force-reinstall $extra_flags"
@@ -608,11 +612,9 @@ install_pycryptodome_fallback() {
     case "$DISTRO_ID" in
         ubuntu|linuxmint|pop|elementary|zorin|debian|raspbian)
             if command -v apt >/dev/null 2>&1; then
-                if sudo apt install -y python3-cryptography 2>/dev/null; then
-                    log "Installed python3-cryptography as alternative to pycryptodome"
-                    # Test if cryptography can be used as a fallback
-                    if python3 -c "from cryptography.hazmat.primitives.ciphers import Cipher; print('cryptography import successful')" 2>/dev/null; then
-                        success "cryptography installed as pycryptodome alternative"
+                if sudo apt install -y python3-pycryptodome 2>/dev/null || sudo apt install -y python3-pycryptodomex 2>/dev/null; then
+                    if verify_pycryptodome_installation; then
+                        success "Installed pycryptodome package via apt"
                         return 0
                     fi
                 fi
@@ -620,21 +622,21 @@ install_pycryptodome_fallback() {
             ;;
         arch|manjaro|endeavouros|cachyos|garuda|artix)
             if command -v pacman >/dev/null 2>&1; then
-                if sudo pacman -S --noconfirm python-cryptography 2>/dev/null; then
-                    log "Installed python-cryptography as alternative to pycryptodome"
-                    if python3 -c "from cryptography.hazmat.primitives.ciphers import Cipher; print('cryptography import successful')" 2>/dev/null; then
-                        success "cryptography installed as pycryptodome alternative"
+                if sudo pacman -S --noconfirm --needed python-pycryptodome 2>/dev/null || sudo pacman -S --noconfirm --needed python-pycryptodomex 2>/dev/null; then
+                    if verify_pycryptodome_installation; then
+                        success "Installed pycryptodome package via pacman"
                         return 0
                     fi
                 fi
             fi
             ;;
         fedora|rhel|centos|almalinux|rocky|bazzite|ublue-os)
-            if command -v dnf >/dev/null 2>&1; then
-                if sudo dnf install -y python3-cryptography 2>/dev/null; then
-                    log "Installed python3-cryptography as alternative to pycryptodome"
-                    if python3 -c "from cryptography.hazmat.primitives.ciphers import Cipher; print('cryptography import successful')" 2>/dev/null; then
-                        success "cryptography installed as pycryptodome alternative"
+            local dnf_cmd
+            dnf_cmd=$(resolve_cmd dnf yum)
+            if [ -n "$dnf_cmd" ]; then
+                if sudo "$dnf_cmd" install -y python3-pycryptodome 2>/dev/null || sudo "$dnf_cmd" install -y python3-pycryptodomex 2>/dev/null; then
+                    if verify_pycryptodome_installation; then
+                        success "Installed pycryptodome package via $dnf_cmd"
                         return 0
                     fi
                 fi
@@ -665,7 +667,7 @@ install_python_packages_via_pip() {
     # Install packages via pip
     # Try with --break-system-packages for Ubuntu 25.04+ which has externally-managed-environment
     # Use pycryptodomex to support "Cryptodome" imports
-    PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone keystone-engine pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
+    PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone keystone-engine pycryptodome pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
     
     if install_python_packages python3 $PYTHON_PACKAGES; then
         success "Python packages installed via pip successfully"
@@ -1119,7 +1121,7 @@ install_chromeos_deps() {
         
         # Install Python packages via pip (ChromeOS may not have PySide6 in repos)
         # Use pycryptodomex to support "Cryptodome" imports
-        pip3 install --user --break-system-packages PySide6 requests lxml configparser colorama capstone pycryptodomex usb pyusb libusb1 pyserial adbutils
+        python3 -m pip install --user --break-system-packages PySide6 requests lxml configparser colorama capstone pycryptodome pycryptodomex usb pyusb libusb1 pyserial adbutils
         
         # Verify pycryptodome installation for ChromeOS
         if ! verify_pycryptodome_installation; then
@@ -1173,7 +1175,7 @@ install_generic_deps() {
     # Install Python packages via pip
     # Try with --break-system-packages for Ubuntu 25.04+ which has externally-managed-environment
     # Use pycryptodomex to support "Cryptodome" imports
-    PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
+    PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone pycryptodome pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
     
     log "Installing Python packages..."
     if ! install_python_packages python3 $PYTHON_PACKAGES; then
@@ -1391,10 +1393,10 @@ setup_mtkclient_requirements() {
     
     # Check for required Python packages for MTKClient
     log "Checking MTKClient Python dependencies..."
-    local required_packages=("pycryptodomex" "pyusb" "libusb1" "pyserial" "lxml")
+    local required_packages=("Crypto" "Cryptodome" "pyusb" "usb" "serial" "lxml")
     
     for package in "${required_packages[@]}"; do
-        if python3 -c "import $package" 2>/dev/null; then
+        if python3 -c "import ${package}" 2>/dev/null; then
             success "Python package $package is available"
         else
             warning "Python package $package is missing - will be installed later"

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -30,6 +30,103 @@ success() {
     echo -e "${GREEN}[SUCCESS]${NC} $1"
 }
 
+# Use first available command from a candidate list
+resolve_cmd() {
+    for candidate in "$@"; do
+        if command -v "$candidate" >/dev/null 2>&1; then
+            echo "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Return 0 for immutable/ostree style systems where package managers may be read-only
+is_immutable_system() {
+    [ -e /run/ostree-booted ] || [ -f /usr/lib/os-release ] && grep -qi "ostree" /usr/lib/os-release 2>/dev/null
+}
+
+# Ensure pip tooling exists for the provided Python executable
+ensure_pip_tools() {
+    local py_bin="${1:-python3}"
+
+    if ! command -v "$py_bin" >/dev/null 2>&1; then
+        warning "Python executable not found: $py_bin"
+        return 1
+    fi
+
+    if "$py_bin" -m pip --version >/dev/null 2>&1; then
+        return 0
+    fi
+
+    log "pip not available for $py_bin, attempting bootstrap..."
+    if "$py_bin" -m ensurepip --upgrade >/dev/null 2>&1; then
+        success "Bootstrapped pip using ensurepip"
+    else
+        warning "ensurepip failed for $py_bin"
+    fi
+
+    if "$py_bin" -m pip --version >/dev/null 2>&1; then
+        return 0
+    fi
+
+    case "$DISTRO_ID" in
+        ubuntu|linuxmint|pop|elementary|zorin|debian|raspbian)
+            sudo apt-get update >/dev/null 2>&1 || true
+            sudo apt-get install -y python3-pip python3-setuptools python3-venv >/dev/null 2>&1 || true
+            ;;
+        arch|manjaro|endeavouros|cachyos|garuda|artix)
+            sudo pacman -Sy --noconfirm >/dev/null 2>&1 || true
+            sudo pacman -S --noconfirm python-pip python-setuptools >/dev/null 2>&1 || true
+            ;;
+        fedora|rhel|centos|almalinux|rocky|bazzite|ublue-os)
+            local dnf_cmd
+            dnf_cmd=$(resolve_cmd dnf yum)
+            if [ -n "$dnf_cmd" ]; then
+                sudo "$dnf_cmd" install -y python3-pip python3-setuptools >/dev/null 2>&1 || true
+            fi
+            ;;
+        opensuse*|sles)
+            sudo zypper install -y python3-pip python3-setuptools >/dev/null 2>&1 || true
+            ;;
+    esac
+
+    if "$py_bin" -m pip --version >/dev/null 2>&1; then
+        success "pip is now available for $py_bin"
+        return 0
+    fi
+
+    warning "pip is still unavailable for $py_bin"
+    return 1
+}
+
+# Install python packages with graceful fallback and package isolation flags when needed
+install_python_packages() {
+    local py_bin="$1"
+    shift
+    local packages=("$@")
+
+    if ! ensure_pip_tools "$py_bin"; then
+        warning "Skipping Python package installation: pip unavailable for $py_bin"
+        return 1
+    fi
+
+    local base_args=("-m" "pip" "install")
+    local user_args=()
+    if [ "$py_bin" = "python3" ]; then
+        user_args+=("--user")
+    fi
+
+    if "$py_bin" "${base_args[@]}" "${user_args[@]}" --break-system-packages "${packages[@]}" >/dev/null 2>&1; then
+        return 0
+    fi
+    if "$py_bin" "${base_args[@]}" "${user_args[@]}" "${packages[@]}" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    return 1
+}
+
 # Detect system architecture
 detect_architecture() {
     ARCH=$(uname -m)
@@ -71,11 +168,16 @@ detect_distro() {
         DISTRO_ID="$ID"
         DISTRO_VERSION="$VERSION_ID"
         DISTRO_NAME="$NAME"
-        
-        # Special handling for Raspberry Pi OS
+        DISTRO_ID_LIKE="${ID_LIKE:-}"
+
+        # Special handling for Raspberry Pi OS and known derivatives
         if [ "$ID" = "debian" ] && [ -f /etc/rpi-issue ]; then
             DISTRO_ID="raspbian"
             DISTRO_NAME="Raspberry Pi OS"
+        elif [ "$ID" = "cachyos" ]; then
+            DISTRO_ID="cachyos"
+        elif [ "$ID" = "bazzite" ]; then
+            DISTRO_ID="bazzite"
         fi
     elif [ -f /etc/redhat-release ]; then
         DISTRO_ID="rhel"
@@ -233,8 +335,15 @@ setup_virtual_environment() {
     if python3 -m venv "$VENV_DIR"; then
         success "Virtual environment created at $VENV_DIR"
     else
-        error "Failed to create virtual environment"
-        return 1
+        warning "Standard venv creation failed, retrying with ensurepip..."
+        if python3 -m venv --without-pip "$VENV_DIR" && python3 -m ensurepip --upgrade >/dev/null 2>&1; then
+            if ! "$VENV_DIR/bin/python" -m ensurepip --upgrade >/dev/null 2>&1; then
+                warning "Could not bootstrap pip inside venv via ensurepip"
+            fi
+        else
+            error "Failed to create virtual environment"
+            return 1
+        fi
     fi
     
     # Define Python packages for virtual environment
@@ -243,19 +352,19 @@ setup_virtual_environment() {
     
     # Activate virtual environment and install packages
     log "Installing Python packages in virtual environment..."
-    if source "$VENV_DIR/bin/activate" && pip install --upgrade pip; then
+    "$VENV_DIR/bin/python" -m ensurepip --upgrade >/dev/null 2>&1 || true
+    if "$VENV_DIR/bin/python" -m pip install --upgrade pip setuptools wheel; then
         success "pip upgraded in virtual environment"
     else
-        error "Failed to upgrade pip in virtual environment"
-        return 1
+        warning "Failed to upgrade pip in virtual environment; continuing with existing pip"
     fi
-    
+
     # Install all required packages with pycryptodome verification
-    if source "$VENV_DIR/bin/activate" && pip install $PYTHON_PACKAGES; then
+    if install_python_packages "$VENV_DIR/bin/python" $PYTHON_PACKAGES; then
         success "Python packages installed in virtual environment"
     else
-        error "Failed to install Python packages in virtual environment"
-        return 1
+        warning "Failed to install one or more Python packages in virtual environment"
+        warning "Application may still run if missing packages are optional"
     fi
     
     # Check and fix pycryptodome installation if needed
@@ -503,7 +612,7 @@ install_pycryptodome_fallback() {
                 fi
             fi
             ;;
-        arch|manjaro|endeavouros)
+        arch|manjaro|endeavouros|cachyos|garuda|artix)
             if command -v pacman >/dev/null 2>&1; then
                 if sudo pacman -S --noconfirm python-cryptography 2>/dev/null; then
                     log "Installed python-cryptography as alternative to pycryptodome"
@@ -514,7 +623,7 @@ install_pycryptodome_fallback() {
                 fi
             fi
             ;;
-        fedora|rhel|centos|almalinux|rocky)
+        fedora|rhel|centos|almalinux|rocky|bazzite|ublue-os)
             if command -v dnf >/dev/null 2>&1; then
                 if sudo dnf install -y python3-cryptography 2>/dev/null; then
                     log "Installed python3-cryptography as alternative to pycryptodome"
@@ -542,9 +651,8 @@ fix_cryptodome_imports() {
 install_python_packages_via_pip() {
     log "Installing Python packages via pip..."
     
-    # Check if pip is available
-    if ! command -v pip3 >/dev/null 2>&1; then
-        warning "pip3 not available, skipping Python package installation"
+    if ! ensure_pip_tools python3; then
+        warning "pip tooling unavailable for system python, skipping global user package install"
         return 1
     fi
     
@@ -553,14 +661,11 @@ install_python_packages_via_pip() {
     # Use pycryptodomex to support "Cryptodome" imports
     PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone keystone-engine pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
     
-    if pip3 install --user --break-system-packages $PYTHON_PACKAGES 2>/dev/null; then
-        success "Python packages installed via pip successfully"
-    elif pip3 install --user $PYTHON_PACKAGES 2>/dev/null; then
+    if install_python_packages python3 $PYTHON_PACKAGES; then
         success "Python packages installed via pip successfully"
     else
         warning "Failed to install some Python packages via pip"
-        warning "You may need to install them manually later"
-        warning "Try: pip3 install --user --break-system-packages $PYTHON_PACKAGES"
+        warning "You may need to install them manually later with: python3 -m pip install --user --break-system-packages $PYTHON_PACKAGES"
     fi
     
     # Verify pycryptodome installation
@@ -584,10 +689,10 @@ install_dependencies() {
         raspbian)
             install_raspbian_deps
             ;;
-        arch|manjaro|endeavouros)
+        arch|manjaro|endeavouros|cachyos|garuda|artix)
             install_arch_deps
             ;;
-        fedora|rhel|centos|almalinux|rocky)
+        fedora|rhel|centos|almalinux|rocky|bazzite|ublue-os)
             install_fedora_deps
             ;;
         opensuse*|sles)
@@ -776,7 +881,13 @@ install_raspbian_deps() {
 # Arch-based distributions
 install_arch_deps() {
     log "Installing dependencies for Arch-based distribution..."
-    
+
+    if is_immutable_system; then
+        warning "Immutable/ostree system detected; skipping pacman system package install"
+        install_python_packages_via_pip
+        return 0
+    fi
+
     # Update package database
     sudo pacman -Sy
     
@@ -797,31 +908,46 @@ install_arch_deps() {
             ;;
     esac
     
-    sudo pacman -S --noconfirm $BASE_PACKAGES $ARCH_PACKAGES
+    sudo pacman -S --noconfirm --needed $BASE_PACKAGES $ARCH_PACKAGES || warning "Some Arch dependencies failed to install"
     
     # Install Python packages (try PySide6 first, fallback to PySide2)
-    if sudo pacman -S --noconfirm \
+    if sudo pacman -S --noconfirm --needed \
         python-pyside6 \
         python-requests \
         python-lxml 2>/dev/null; then
         success "PySide6 packages installed successfully"
     else
         warning "PySide6 not available, trying PySide2..."
-        sudo pacman -S --noconfirm \
+        sudo pacman -S --noconfirm --needed \
             python-pyside2 \
             python-requests \
-            python-lxml
+            python-lxml || warning "PySide2 fallback package installation failed"
     fi
     
+    install_python_packages_via_pip
     success "Arch dependencies installed successfully"
 }
 
 # Fedora/RHEL-based distributions
 install_fedora_deps() {
     log "Installing dependencies for Fedora/RHEL-based distribution..."
-    
+
+    if is_immutable_system; then
+        warning "Immutable/ostree system detected; skipping system package install"
+        install_python_packages_via_pip
+        return 0
+    fi
+
+    local dnf_cmd
+    dnf_cmd=$(resolve_cmd dnf yum)
+    if [ -z "$dnf_cmd" ]; then
+        warning "dnf/yum not available; using generic dependency flow"
+        install_generic_deps
+        return 0
+    fi
+
     # Update package database
-    sudo dnf update -y
+    sudo "$dnf_cmd" update -y
     
     # Base packages for all architectures
     # MTKClient requirements: fuse, fuse-devel, libusb1-devel
@@ -840,22 +966,23 @@ install_fedora_deps() {
             ;;
     esac
     
-    sudo dnf install -y $BASE_PACKAGES $ARCH_PACKAGES
+    sudo "$dnf_cmd" install -y $BASE_PACKAGES $ARCH_PACKAGES || warning "Some Fedora/RHEL dependencies failed to install"
     
     # Install Python packages (try PySide6 first, fallback to PySide2)
-    if sudo dnf install -y \
+    if sudo "$dnf_cmd" install -y \
         python3-PySide6 \
         python3-requests \
         python3-lxml 2>/dev/null; then
         success "PySide6 packages installed successfully"
     else
         warning "PySide6 not available, trying PySide2..."
-        sudo dnf install -y \
+        sudo "$dnf_cmd" install -y \
             python3-PySide2 \
             python3-requests \
-            python3-lxml
+            python3-lxml || warning "PySide2 fallback package installation failed"
     fi
     
+    install_python_packages_via_pip
     success "Fedora/RHEL dependencies installed successfully"
 }
 
@@ -1021,11 +1148,17 @@ install_generic_deps() {
         sudo apt update 2>/dev/null || true
         sudo apt install -y build-essential cmake pkg-config libusb-1.0-0-dev 2>/dev/null || warning "Could not install build tools via apt"
     elif command -v pacman >/dev/null 2>&1; then
-        sudo pacman -Sy 2>/dev/null || true
-        sudo pacman -S --noconfirm base-devel cmake pkgconf libusb 2>/dev/null || warning "Could not install build tools via pacman"
-    elif command -v dnf >/dev/null 2>&1; then
-        sudo dnf update -y 2>/dev/null || true
-        sudo dnf install -y gcc gcc-c++ make cmake pkgconfig libusb1-devel 2>/dev/null || warning "Could not install build tools via dnf"
+        if is_immutable_system; then
+            warning "Immutable/ostree system detected; skipping pacman build tool install"
+        else
+            sudo pacman -Sy 2>/dev/null || true
+            sudo pacman -S --noconfirm base-devel cmake pkgconf libusb 2>/dev/null || warning "Could not install build tools via pacman"
+        fi
+    elif command -v dnf >/dev/null 2>&1 || command -v yum >/dev/null 2>&1; then
+        local dnf_cmd
+        dnf_cmd=$(resolve_cmd dnf yum)
+        sudo "$dnf_cmd" update -y 2>/dev/null || true
+        sudo "$dnf_cmd" install -y gcc gcc-c++ make cmake pkgconfig libusb1-devel 2>/dev/null || warning "Could not install build tools via $dnf_cmd"
     elif command -v zypper >/dev/null 2>&1; then
         sudo zypper refresh 2>/dev/null || true
         sudo zypper install -y gcc gcc-c++ make cmake pkg-config libusb-1_0-devel 2>/dev/null || warning "Could not install build tools via zypper"
@@ -1037,21 +1170,19 @@ install_generic_deps() {
     PYTHON_PACKAGES="PySide6 requests lxml configparser colorama capstone pycryptodomex usb pyusb libusb1 pyserial adbutils pillow numpy"
     
     log "Installing Python packages..."
-    if ! pip3 install --user --break-system-packages $PYTHON_PACKAGES 2>/dev/null; then
-        if ! pip3 install --user $PYTHON_PACKAGES 2>/dev/null; then
-            warning "Some Python packages failed to install. Trying individual packages..."
-            for package in $PYTHON_PACKAGES; do
-                if ! pip3 install --user --break-system-packages $package 2>/dev/null; then
-                    pip3 install --user $package 2>/dev/null || warning "Failed to install $package"
-                fi
-            done
-        fi
+    if ! install_python_packages python3 $PYTHON_PACKAGES; then
+        warning "Some Python packages failed to install. Trying individual packages..."
+        for package in $PYTHON_PACKAGES; do
+            if ! install_python_packages python3 "$package"; then
+                warning "Failed to install $package"
+            fi
+        done
     fi
     
     # Try to install keystone-engine separately (it often needs build tools)
     log "Attempting to install keystone-engine..."
-    if ! pip3 install --user --break-system-packages keystone-engine 2>/dev/null; then
-        pip3 install --user keystone-engine 2>/dev/null || warning "keystone-engine failed to install (requires cmake and build tools)"
+    if ! install_python_packages python3 keystone-engine; then
+        warning "keystone-engine failed to install (requires cmake and build tools)"
     fi
     
     # Verify pycryptodome installation
@@ -1435,10 +1566,10 @@ get_install_dir() {
         ubuntu|linuxmint|pop|elementary|zorin|debian)
             INSTALL_DIR="/home/$USER/.local/share/innioasis-updater"
             ;;
-        arch|manjaro|endeavouros)
+        arch|manjaro|endeavouros|cachyos|garuda|artix)
             INSTALL_DIR="/home/$USER/.local/share/innioasis-updater"
             ;;
-        fedora|rhel|centos|almalinux|rocky)
+        fedora|rhel|centos|almalinux|rocky|bazzite|ublue-os)
             INSTALL_DIR="/home/$USER/.local/share/innioasis-updater"
             ;;
         opensuse*|sles)

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -2217,7 +2217,7 @@ Usage:
 Options:
   -h, --help     Show this help message
   -i, --install  Install Innioasis Updater (default)
-  -u, --uninstall Uninstall Innioasis Updater
+  -u, --uninstall, -uninstall  Uninstall Innioasis Updater
   -l, --launch   Launch Innioasis Updater (if already installed)
   --update       Update Innioasis Updater to latest version
   --cleanup      Clean up partial installations and temporary files
@@ -2274,6 +2274,26 @@ uninstall() {
     if [ -f "$HOME/.local/share/applications/innioasis-updater.desktop" ]; then
         rm -f "$HOME/.local/share/applications/innioasis-updater.desktop"
         success "Removed desktop entry"
+    fi
+
+    # Remove udev rules created by installer
+    if [ -f "/etc/udev/rules.d/99-mediatek.rules" ]; then
+        if sudo rm -f "/etc/udev/rules.d/99-mediatek.rules"; then
+            success "Removed udev rules: /etc/udev/rules.d/99-mediatek.rules"
+            sudo udevadm control --reload-rules >/dev/null 2>&1 || true
+            sudo udevadm trigger >/dev/null 2>&1 || true
+        else
+            warning "Failed to remove udev rules file"
+        fi
+    fi
+
+    # Remove qcaux blacklist line added by installer, if present
+    if [ -f "/etc/modprobe.d/blacklist.conf" ] && grep -q '^blacklist qcaux$' "/etc/modprobe.d/blacklist.conf"; then
+        if sudo sed -i '/^blacklist qcaux$/d' "/etc/modprobe.d/blacklist.conf"; then
+            success "Removed qcaux blacklist entry from /etc/modprobe.d/blacklist.conf"
+        else
+            warning "Failed to remove qcaux blacklist entry"
+        fi
     fi
     
     # Update desktop database
@@ -2398,7 +2418,7 @@ case "${1:-}" in
         show_help
         exit 0
         ;;
-    -u|--uninstall)
+    -u|--uninstall|-uninstall)
         uninstall
         exit 0
         ;;

--- a/run_linux.sh
+++ b/run_linux.sh
@@ -554,8 +554,11 @@ install_pycryptodome_fallback() {
     log "Attempting to install pycryptodome from source..."
     
     if command -v git >/dev/null 2>&1; then
-        local temp_dir=$(mktemp -d)
-        cd "$temp_dir"
+        local temp_dir
+        local original_cwd
+        temp_dir=$(mktemp -d)
+        original_cwd=$(pwd)
+        cd "$temp_dir" || return 1
         
         if git clone https://github.com/Legrandin/pycryptodome.git 2>/dev/null; then
             cd pycryptodome
@@ -578,6 +581,7 @@ install_pycryptodome_fallback() {
                 if source "$venv_dir/bin/activate" && python setup.py build_ext --inplace && pip install . 2>/dev/null; then
                     if verify_pycryptodome_installation "$venv_dir"; then
                         success "pycryptodome installed from source successfully"
+                        cd "$original_cwd" || true
                         rm -rf "$temp_dir"
                         return 0
                     fi
@@ -586,6 +590,7 @@ install_pycryptodome_fallback() {
                 if python3 setup.py build_ext --inplace && pip3 install . 2>/dev/null; then
                     if verify_pycryptodome_installation; then
                         success "pycryptodome installed from source successfully"
+                        cd "$original_cwd" || true
                         rm -rf "$temp_dir"
                         return 0
                     fi
@@ -593,6 +598,7 @@ install_pycryptodome_fallback() {
             fi
         fi
         
+        cd "$original_cwd" || true
         rm -rf "$temp_dir"
     fi
     
@@ -893,7 +899,7 @@ install_arch_deps() {
     
     # Base packages for all architectures
     # MTKClient requirements: fuse2, fuse3, libusb
-    BASE_PACKAGES="python python-pip python-virtualenv python-setuptools pkgconf base-devel git curl wget unzip udev usbutils cmake gcc gcc-libs make libffi openssl zlib bzip2 readline sqlite tk libxml2 xz-utils ncurses android-tools fuse2 fuse3 libusb"
+    BASE_PACKAGES="python python-pip python-virtualenv python-setuptools pkgconf base-devel git curl wget unzip udev usbutils cmake gcc gcc-libs make libffi openssl zlib bzip2 readline sqlite tk libxml2 xz ncurses android-tools fuse2 fuse3 libusb"
     
     # Architecture-specific packages
     case "$ARCH_TYPE" in
@@ -1216,7 +1222,9 @@ install_android_tools_fallback() {
     
     # Create temporary directory
     TEMP_DIR=$(mktemp -d)
-    cd "$TEMP_DIR"
+    local original_cwd
+    original_cwd=$(pwd)
+    cd "$TEMP_DIR" || return 1
     
     # Download Android Platform Tools
     log "Downloading Android Platform Tools..."
@@ -1225,6 +1233,7 @@ install_android_tools_fallback() {
             success "Downloaded Android Platform Tools"
         else
             warning "Failed to download Android Platform Tools with wget"
+            cd "$original_cwd" || true
             rm -rf "$TEMP_DIR"
             return 1
         fi
@@ -1233,11 +1242,13 @@ install_android_tools_fallback() {
             success "Downloaded Android Platform Tools"
         else
             warning "Failed to download Android Platform Tools with curl"
+            cd "$original_cwd" || true
             rm -rf "$TEMP_DIR"
             return 1
         fi
     else
         warning "Neither wget nor curl available for downloading Android Platform Tools"
+        cd "$original_cwd" || true
         rm -rf "$TEMP_DIR"
         return 1
     fi
@@ -1248,11 +1259,13 @@ install_android_tools_fallback() {
             success "Extracted Android Platform Tools"
         else
             warning "Failed to extract Android Platform Tools"
+            cd "$original_cwd" || true
             rm -rf "$TEMP_DIR"
             return 1
         fi
     else
         warning "unzip not available for extracting Android Platform Tools"
+        cd "$original_cwd" || true
         rm -rf "$TEMP_DIR"
         return 1
     fi
@@ -1268,11 +1281,13 @@ install_android_tools_fallback() {
         log "Note: You may need to add $USER_BIN_DIR to your PATH"
     else
         warning "Failed to install Android Platform Tools"
+        cd "$original_cwd" || true
         rm -rf "$TEMP_DIR"
         return 1
     fi
     
     # Clean up
+    cd "$original_cwd" || true
     rm -rf "$TEMP_DIR"
     return 0
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- improve distro handling for Arch/Fedora derivatives by recognizing `cachyos` and `bazzite` explicitly and mapping broader distro families in dependency paths
- add robust Python bootstrap helpers to recover when `pip` is missing (`ensurepip` + distro package fallbacks)
- make virtualenv setup resilient when pip/setuptools are absent and avoid hard failure on pip upgrade/install hiccups
- add immutable/ostree safeguards to skip unsupported system package install steps while still attempting user-space Python package setup
- use `python3 -m pip` based installation helper with `--break-system-packages` fallback behavior to support externally managed Python environments
- make Arch/Fedora dependency installation paths more defensive (`--needed`, `dnf/yum` resolution, warning-only failures)
- fix a critical temp-directory cleanup bug where the script removed a directory while still `cd`'d into it, causing subsequent `pip`/venv operations to fail with `FileNotFoundError: getcwd`
- fix Arch package naming by replacing invalid `xz-utils` with `xz`
- prioritize `pycryptodome` (Crypto namespace) over `pycryptodomex`, and add package-manager fallbacks (`python3-pycryptodome` / `python-pycryptodome`) so MTKClient imports like `from Crypto.Util.number import bytes_to_long` work reliably
- add `-uninstall` flag alias and strengthen uninstall to remove installer-created system artifacts (udev rule + qcaux blacklist entry)
- make MTKClient crypto imports lazy across key Python modules so startup does not crash when crypto backends are absent; operations requiring crypto now fail at call-time with explicit install guidance

## Verification
- `bash -n run_linux.sh`
- `bash run_linux.sh --help`
- `python3 -m py_compile` for updated MTKClient Python modules

## Problem addressed
This removes hard import-time crashes from crypto dependencies and keeps MTKClient usable for non-crypto paths while still signaling clearly when a crypto operation is invoked without pycryptodome.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9d43dc6-95ee-44b7-9731-21d9e63dbfa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9d43dc6-95ee-44b7-9731-21d9e63dbfa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

