### PR TITLE
Fix installation prompt images being truncated

### DIFF
--- a/firmware_downloader.py
+++ b/firmware_downloader.py
@@ -32,7 +32,7 @@ from PySide6.QtWidgets import (QApplication, QMainWindow, QVBoxLayout, QHBoxLayo
                                QLabel, QComboBox, QProgressBar, QMessageBox,
                                QGroupBox, QSplitter, QStackedWidget, QCheckBox, QProgressDialog,
                                QFileDialog, QDialog, QDialogButtonBox, QTabWidget, QScrollArea, QTextBrowser, QLineEdit,
-                               QTreeWidget, QTreeWidgetItem, QTreeView, QAbstractItemView)
+                               QTreeWidget, QTreeWidgetItem, QTreeView, QAbstractItemView, QSizePolicy)
 from PySide6.QtCore import QThread, Signal, Qt, QSize, QTimer, QPropertyAnimation, QEasingCurve, QObject, QMimeData, QEvent
 from PySide6.QtGui import (QFont, QPixmap, QTextDocument, QPalette, QDragEnterEvent,
                            QDropEvent, QIcon, QImage, QPainter, QColor)
@@ -8188,6 +8188,7 @@ class FirmwareDownloaderGUI(QMainWindow):
         # Image widget (page 0)
         self.image_label = QLabel()
         self.image_label.setAlignment(Qt.AlignCenter)
+        self.image_label.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Ignored)
         self.image_label.setStyleSheet("""
             QLabel {
                 background-color: transparent;
@@ -15760,20 +15761,30 @@ class FirmwareDownloaderGUI(QMainWindow):
         if pixmap.isNull():
             return
 
-        # Get the label size
-        label_size = self.image_label.size()
-        if label_size.width() <= 0 or label_size.height() <= 0:
-            # Use minimum size if label not properly sized yet
-            label_size = QSize(400, 300)
+        # Prefer the actual available stack area to avoid clipped prompt images.
+        if hasattr(self, 'image_notes_stack') and self.image_notes_stack is not None:
+            target_size = self.image_notes_stack.contentsRect().size()
+        else:
+            target_size = self.image_label.contentsRect().size()
+
+        if target_size.width() <= 0 or target_size.height() <= 0:
+            target_size = self.image_label.size()
+
+        if target_size.width() <= 0 or target_size.height() <= 0:
+            target_size = QSize(400, 300)
+
+        # Keep a small margin so frame/border rendering never clips content.
+        target_size = QSize(max(1, target_size.width() - 8), max(1, target_size.height() - 8))
 
         # Scale image to fit the label while maintaining aspect ratio
         scaled_pixmap = pixmap.scaled(
-            label_size,
+            target_size,
             Qt.KeepAspectRatio,
             Qt.SmoothTransformation
         )
 
         # Set the scaled pixmap
+        self.image_label.setMinimumSize(1, 1)
         self.image_label.setPixmap(scaled_pixmap)
 
         # Don't use setScaledContents to maintain aspect ratio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- update image prompt rendering to scale against the actual available stacked-widget content area (not just current label hint size)
- set the installation image label to `QSizePolicy.Ignored` so it can shrink reliably in constrained layouts
- add a small sizing margin to avoid edge/frame clipping during high-DPI or Wayland/KDE layouts
- keep aspect ratio preserved for all installation prompt images (`presteps`, `initsteps`, `installing`, `installed`, etc.)

## Validation
- `python3 -m py_compile /workspace/firmware_downloader.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9d43dc6-95ee-44b7-9731-21d9e63dbfa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9d43dc6-95ee-44b7-9731-21d9e63dbfa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

