### PR TITLE
Point Y2 Rockbox catalogue to upstream Beta V2 releases

### DIFF
--- a/slidia_manifest.xml
+++ b/slidia_manifest.xml
@@ -8,7 +8,7 @@
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y1" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y2" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Rockbox" repo="rockbox-y1/rockbox" device="Y1" url="https://github.com/rockbox-y1/rockbox" type="img" handler="Custom Firmware" /> 
-<package name="Rockbox" repo="y1-community/rockbox-y2-rom" device="Y2" url="https://github.com/y1-community/rockbox-y2-rom" type="img" handler="Custom Firmware" /> 
+<package name="Rockbox" repo="SPYCEMAGIC/Y2-Rockbox" device="Y2" url="https://github.com/SPYCEMAGIC/Y2-Rockbox" type="img" handler="Custom Firmware" /> 
 <package name="Koensayr" repo="ryan-specter/koensayr-auto" device="Y1" url="https://github.com/ryan-specter/koensayr-auto" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y1" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y2" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />

--- a/slidia_manifest.xml
+++ b/slidia_manifest.xml
@@ -8,7 +8,7 @@
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y1" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y2" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Rockbox" repo="rockbox-y1/rockbox" device="Y1" url="https://github.com/rockbox-y1/rockbox" type="img" handler="Custom Firmware" /> 
-<package name="Rockbox" repo="SPYCEMAGIC/Y2-Rockbox" device="Y2" url="https://github.com/SPYCEMAGIC/Y2-Rockbox" type="img" handler="Custom Firmware" /> 
+<package name="Rockbox" repo="SPYCEMAGIC/Y2-Rockbox" device="Y2" url="https://github.com/SPYCEMAGIC/Y2-Rockbox" type="img" handler="Custom Firmware" />
 <package name="Koensayr" repo="ryan-specter/koensayr-auto" device="Y1" url="https://github.com/ryan-specter/koensayr-auto" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y1" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y2" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />


### PR DESCRIPTION
## Summary

Point the Y2 Rockbox catalogue entry directly to the upstream
`SPYCEMAGIC/Y2-Rockbox` releases instead of the community mirror.

## Published release contract

Beta V2 is public at:

https://github.com/SPYCEMAGIC/Y2-Rockbox/releases/tag/v0.2.0-beta

It includes both:

- `Y2-Rockbox-Beta-v0.2.0-InnioasisUpdater.zip`, retaining the previous public
  sparse-image package type; and
- canonical `rom_y2.zip`, prepared for Updater CE with raw `system.img`,
  `cache.img` and `userdata.img` plus the standard Y2 support files.

Published `rom_y2.zip`:

- size: 370,911,657 bytes
- SHA-256: `22195AB5EF775585D73929C05B2FED28BB497C150705A91CC484A02308EB2A46`
- GitHub asset state: uploaded
- GitHub server digest: matching SHA-256

Its raw `system.img` matches the full physical ANDROID readback from the
accepted P17 release gate.

## Validation

- `slidia_manifest.xml` parses successfully with Python's XML parser.
- The changed entry remains `device="Y2"`, `type="img"`, and
  `handler="Custom Firmware"`.
- Only the Y2 Rockbox `repo` and `url` ownership fields change.
- The release exposes the exact canonical `rom_y2.zip` asset required by the
  current Updater CE Y2 detection contract.

Related project issue:
https://github.com/SPYCEMAGIC/Y2-Rockbox/issues/6