### PR TITLE
Point Y2 Rockbox catalogue to corrected Beta V2 package

### DIFF
--- a/slidia_manifest.xml
+++ b/slidia_manifest.xml
@@ -8,7 +8,7 @@
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y1" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y2" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Rockbox" repo="rockbox-y1/rockbox" device="Y1" url="https://github.com/rockbox-y1/rockbox" type="img" handler="Custom Firmware" /> 
-<package name="Rockbox" repo="y1-community/rockbox-y2-rom" device="Y2" url="https://github.com/y1-community/rockbox-y2-rom" type="img" handler="Custom Firmware" /> 
+<package name="Rockbox" repo="SPYCEMAGIC/Y2-Rockbox" device="Y2" url="https://github.com/SPYCEMAGIC/Y2-Rockbox" type="img" handler="Custom Firmware" />
 <package name="Koensayr" repo="ryan-specter/koensayr-auto" device="Y1" url="https://github.com/ryan-specter/koensayr-auto" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y1" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y2" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />


### PR DESCRIPTION
## Summary

Point the Updater CE Y2 Rockbox catalogue entry directly at the official
`SPYCEMAGIC/Y2-Rockbox` release repository.

This supersedes closed PR #42. The package linked by that PR was withdrawn
after a public Windows Updater CE attempt left a Y2 unable to boot. The user
recovered the device with stock firmware. Investigation found that the package
contained only five enabled partitions while the Windows path performs a full
format before downloading the listed partitions.

## Corrected package

The replacement `rom_y2.zip` restores the exact Beta V1 full-install scatter
and its complete 12-partition set. The accepted Beta V2 runtime images are
unchanged; only the package/install layout was corrected.

- Release: https://github.com/SPYCEMAGIC/Y2-Rockbox/releases/tag/v0.2.0-beta
- Asset: `rom_y2.zip`
- Size: `370,911,650` bytes
- SHA-256: `6ACCB71DAA7ECE7EA25541401002F95EAF8A7AC48DD9E058134F4DAB887F8D46`
- GitHub's server-side asset digest matches that SHA-256.
- Dedicated offline validation: 16/16 checks passed, including a reproducible
  rebuild, exact Beta V1 scatter identity, complete partition coverage, raw
  image requirements, archive member order, and updater command-path checks.

This removes the identified incomplete-restore failure mode. The project owner
has authorized publication now and will perform the remaining physical Windows
Updater CE test on 2026-09-02. Results and any field feedback will be followed
up promptly.

Related request: https://github.com/SPYCEMAGIC/Y2-Rockbox/issues/6
