### PR TITLE
Emergency: temporarily disable Rockbox Y2 installs

### DIFF
--- a/slidia_manifest.xml
+++ b/slidia_manifest.xml
@@ -8,7 +8,6 @@
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y1" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Solar (adds YouTube)" repo="thesolarproject/solar" device="Y2" url="https://github.com/thesolarproject/solar" type="img" handler="Custom Firmware" />
 <package name="Rockbox" repo="rockbox-y1/rockbox" device="Y1" url="https://github.com/rockbox-y1/rockbox" type="img" handler="Custom Firmware" /> 
-<package name="Rockbox" repo="y1-community/rockbox-y2-rom" device="Y2" url="https://github.com/y1-community/rockbox-y2-rom" type="img" handler="Custom Firmware" /> 
 <package name="Koensayr" repo="ryan-specter/koensayr-auto" device="Y1" url="https://github.com/ryan-specter/koensayr-auto" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y1" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />
 <package name="JJ Launcher" repo="ismileblue/y1_launcher" device="Y2" url="https://github.com/ismileblue/y1_launcher" type="img" handler="Custom Firmware" />


### PR DESCRIPTION
Temporarily removes the Rockbox Y2 entry from the Updater CE manifest. The current mirrored v0.2.0-beta package has produced two serious Windows flashing failures, including a device that no longer reaches the bootloader. The owned release assets have been withdrawn and mirror removal is requested in y1-community/rockbox-y2-rom#1. Please merge this containment change urgently; the entry can be restored after a physically validated updater-safe package is available.